### PR TITLE
README.md: Fix example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
       run: ./release-sh
 
     - name: Wait for package to become available
-      uses: databutton/wait-for-pypi@main
+      uses: databutton/wait-for-pypi-action@main
       with:
         package_name: my-package
         package_version: ${{ steps.release.outputs.version }}


### PR DESCRIPTION
The action's repo name is `databutton/wait-for-pypi-action`